### PR TITLE
Can customize what listings you see with query string

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,10 @@ var App = function() {
   var num_height = 5;
   var num_listings = num_width * num_height;
   var listings_url = 'https://reverb.com/api/listings.json?per_page=' + num_listings;
+  var query_string = window.location.search.slice(1);
+  if (query_string.length) {
+    listings_url += "&" + query_string;
+  }
   var $body = $('body');
 
   self.last_listing_title = null;


### PR DESCRIPTION
For example, adding `?product_type=effects-pedals` to the url will only show effects/pedals in the mosaic.
